### PR TITLE
Fixed missing current week and changed period fetching

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    coderay (1.1.2)
-    method_source (0.9.0)
     mini_portile2 (2.3.0)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
-    pry (0.11.1)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
     rb-scpt (1.0.2)
     unidecoder (1.1.2)
 
@@ -17,7 +12,6 @@ PLATFORMS
 
 DEPENDENCIES
   nokogiri
-  pry
   rb-scpt
   unidecoder
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ bundle exec ruby lastfm2itunes.rb -u (your Last.fm username)
 bundle exec ruby lastfm2itunes.rb -u praetorian42
 
 # Example with dry run and add playcounts of the last 4 weeks:
-bundle exec ruby lastfm2itunes.rb -u praetorian42 -d -a 4
+bundle exec ruby lastfm2itunes.rb -u praetorian42 -n -a -w 4
 
 # See help for all options:
 bundle exec ruby lastfm2itunes.rb -h

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Added bonus: Look at iTunes while the script is running and see the play counts 
 ## Prerequisites
 
 * OS X >= 10.11
-* Ruby ~2.x
+* Ruby >= 2.1.0
 
 ## Usage
 


### PR DESCRIPTION
Hi, a few more changes. I realised that the past days were missing from the data and found out that the weeklytrackcharts do not include the current week. I added this.

Also as i have a huge library and many non matching tracks I added another verbosity level to exclude "Couldn't match up" messages as I want to see the updates more clearly when I dry run to check what will happen.

I changed the ---dry-run flag to -n like in rsync as -d is used for the param --days.